### PR TITLE
Set lexical-binding; Don't explicitly create a new buffer

### DIFF
--- a/ob-elixir.el
+++ b/ob-elixir.el
@@ -1,4 +1,4 @@
-;;; ob-elixir.el --- org-babel functions for elixir evaluation
+;;; ob-elixir.el --- org-babel functions for elixir evaluation -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 ZHOU Feng
 
@@ -64,9 +64,7 @@
   (let ((name (format "*elixir-%s*" session)))
     (unless (and (get-process name)
                  (process-live-p (get-process name)))
-      (with-current-buffer (get-buffer-create name)
-        (make-local-variable 'process-environment)
-        (setq process-environment (cons "TERM=vt100" process-environment))
+      (let ((process-environment (cons "TERM=vt100" process-environment)))
         (apply 'start-process name name "iex"
                (append (when (assoc :sname params)
                          (list "--sname" (assoc-default :sname params)))


### PR DESCRIPTION
Setting `lexical-binding` to t is now a recommended practice for all Emacs packages, so I set it. This spares you from explicitly making a local variable of `process-environment`.

It is also important to not wrap `start-process` with a new buffer. If `exec-path` is set locally in the parent Org file and an `iex` executable is only available in the local `exec-path`, you cannot find the executable in the new buffer, which causes an error. Instead, pass the buffer (name) directly to `start-process`.