### PR TITLE
Add :results output option

### DIFF
--- a/README.org
+++ b/README.org
@@ -21,14 +21,25 @@ initialization will enable the mode.
 - remsh
 - sname
 - session
+- results
 
 ** examples
-   
+
 *** connect to remote shell
 
 : #+BEGIN_SRC elixir :remsh name@node :sname console
 : Node.self
 : #+END_SRC
-: 
+:
 : #+RESULTS:
 : : :name@node
+
+*** suppress output of result of computation
+
+: #+BEGIN_SRC elixir :results output
+: IO.puts("displayed")
+: "not displayed"
+: #+END_SRC
+:
+: #+RESULTS:
+: : displayed

--- a/ob-elixir.el
+++ b/ob-elixir.el
@@ -57,13 +57,16 @@
 
 (defun ob-elixir-eval (session body)
   (let ((result (ob-elixir-eval-in-repl session body)))
-    (replace-regexp-in-string
-     "^import_file([^)]+).*\n" ""
+    (string-trim-right
      (replace-regexp-in-string
-      "\r" ""
+      ":\\\"do not show this result in output\\\"" ""
       (replace-regexp-in-string
-       "\n\\(\\(iex\\|[.]+\\)\\(([^@]+@[^)]+)[0-9]+\\|([0-9]+)\\)> \\)+" ""
-       result)))))
+       "^import_file([^)]+).*\n" ""
+       (replace-regexp-in-string
+        "\r" ""
+        (replace-regexp-in-string
+         "\n\\(\\(iex\\|[.]+\\)\\(([^@]+@[^)]+)[0-9]+\\|([0-9]+)\\)> \\)+" ""
+         result)))))))
 
 (defun ob-elixir-ensure-session (session params)
   (let ((name (format "*elixir-%s*" session)))

--- a/ob-elixir.el
+++ b/ob-elixir.el
@@ -45,15 +45,20 @@
 
 (defun org-babel-execute:elixir (body params)
   (let ((session (cdr (assoc :session params)))
+        (result-params (cdr (assq :result-params params)))
         (tmp (org-babel-temp-file "elixir-")))
     (ob-elixir-ensure-session session params)
     (with-temp-file tmp (insert body))
-    (ob-elixir-eval session (format "import_file(\"%s\")" tmp))))
+    (let ((iex-import-expr
+           (if (member "output" result-params)
+               (format "import_file(\"%s\"); IEx.dont_display_result" tmp)
+             (format "import_file(\"%s\")" tmp))))
+      (ob-elixir-eval session iex-import-expr))))
 
 (defun ob-elixir-eval (session body)
   (let ((result (ob-elixir-eval-in-repl session body)))
     (replace-regexp-in-string
-    "^import_file([^)]+)\n" ""
+     "^import_file([^)]+).*\n" ""
      (replace-regexp-in-string
       "\r" ""
       (replace-regexp-in-string


### PR DESCRIPTION
Adding a ":results output" option suppresses the output of the respective computation in IEx. This allows to use IO.puts/2 or IO.inspect/2 without displaying the result of the computation.

Compare
```
      #+BEGIN_SRC elixir :results output
        IO.inspect List.to_string('hello')
        IO.inspect String.to_charlist("hello")
      #+END_SRC

      #+RESULTS:
      : "hello"
      : 'hello'
```
to
```
      #+BEGIN_SRC elixir
        IO.inspect List.to_string('hello')
        IO.inspect String.to_charlist("hello")
      #+END_SRC

      #+RESULTS:
      : "hello"
      : 'hello'
      : 'hello'
```